### PR TITLE
bump dev-drprasad/delete-tag-and-release to 0.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Delete old nightly release
-        uses: dev-drprasad/delete-tag-and-release@v0.1.3
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         if: startsWith(github.ref, 'refs/tags/droidian') != true
         with:
           delete_release: true # default: false


### PR DESCRIPTION
release 0.1.3 is removed and replaced with 0.2.1
new builds will fail with missing tag.