### PR TITLE
Added OnePlus 3/3T

### DIFF
--- a/devices.yml
+++ b/devices.yml
@@ -62,6 +62,11 @@
     - adaptation-droidian-starqlte
     - adaptation-starqlte-configs
 
+.oneplus_oneplus3_packages:
+  packages: &oneplus_oneplus3_packages
+    - adaptation-droidian-oneplus3
+    - adaptation-oneplus3-configs
+
 ########################################################################
 # Recovery-flashable rootfses                                          #
 ########################################################################
@@ -230,3 +235,17 @@ samsung_starqlte:
   apilevel: 29
 
   packages: *samsung_starqlte_packages
+
+#
+# OnePlus
+#
+
+# OnePlus 3/3T (oneplus3)
+oneplus_oneplus3:
+  type: rootfs
+  arch: arm64
+  edition: phosh
+  variant: phone
+  apilevel: 28
+
+  packages: *oneplus_oneplus3_packages

--- a/generate_device_recipe.py
+++ b/generate_device_recipe.py
@@ -178,6 +178,13 @@ def generate_recipe_for_product(contents, product, arch, edition, variant, apile
 
 					if write_end:
 						f.write(TEMPLATE_END)
+		elif config["type"] == "rootfs" and config.get("packages", []):
+			f.write(
+				TEMPLATE_IMAGE_ADAPTATION % {
+					"architecture" : arch,
+					"packages" : " ".join(config["packages"])
+				}
+			)
 		elif config["type"] == "image":
 			f.write(
 				TEMPLATE_IMAGE_ADAPTATION % {


### PR DESCRIPTION
The OnePlus 3/3T uses the rootfs method instead of the LVM image but when generating the yaml file for the device, the adaptation files weren't included.
This has been fixed and should also work with other devices that use the rootfs method and need adaptation packages to be installed.